### PR TITLE
Enforce string when string is the only item type

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ and the Avro object is:
 
 Note that every non-null element inside the `identifier` array field is converted to string.
 
+This enforcement only applies to an array whose items can only be nullable strings. For arrays with union item types, no string enforcing will be carried out.
+
 ### Additional Properties
 
 #### Avro Additional Properties

--- a/converter/src/test/resources/json_avro_converter.json
+++ b/converter/src/test/resources/json_avro_converter.json
@@ -662,6 +662,32 @@
     }
   },
   {
+    "testCase": "typed_array",
+    "avroSchema": {
+      "type": "record",
+      "name": "typed_array",
+      "fields": [
+        {
+          "name": "array_field",
+          "type": [
+            "null",
+            {
+              "type": "array",
+              "items": ["null", "string", "int", "boolean"]
+            }
+          ],
+          "default": null
+        }
+      ]
+    },
+    "jsonObject": {
+      "array_field": [101, "102", true, false, null]
+    },
+    "avroObject": {
+      "array_field": [101, "102", true, false, null]
+    }
+  },
+  {
     "testCase": "unknown_array_to_string_array",
     "description": "Json objects with array fields of unknown types will be converted to string array according to the schema",
     "avroSchema": {


### PR DESCRIPTION
Previously PR #10 aded string enforcing to handle Json arrays without unknown types or array elements that do not follow the schema. However, it also introduced a bug that every element within an array would be converted to string.

This PR fixes this bug by enforcing string conversion when string is the only item type for an array.
