### PR TITLE
Support era and string numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ The original [json-avro-converter](https://github.com/allegro/json-avro-converte
 ## CHANGELOG
 
 | Version | Description |
-| ------- | ----------- |
+|---------| ----------- |
+| 1.0.2   | Support era and string numbers |
 | 1.0.1   | Fix publication to JitPack. |
 | 1.0.0   | Publish to JitPack. |

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/AvroTypeExceptions.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/AvroTypeExceptions.java
@@ -38,4 +38,14 @@ class AvroTypeExceptions {
             .append(offendingValue)
             .toString());
     }
+
+    static AvroTypeException numberFormatException(Deque<String> fieldPath, Object offendingValue) {
+        return new AvroTypeException(new StringBuilder()
+            .append("Field ")
+            .append(PathsPrinter.print(fieldPath))
+            .append(" is expected to be Number format")
+            .append(", but it is: ")
+            .append(offendingValue)
+            .toString());
+    }
 }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/util/DateTimeUtils.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/util/DateTimeUtils.java
@@ -11,27 +11,30 @@ import java.time.format.DateTimeParseException;
 
 public class DateTimeUtils {
 
-    private static final DateTimeFormatter formatter =
-            DateTimeFormatter.ofPattern("[yyyy][yy]['-']['/']['.'][' '][MMM][MM][M]['-']['/']['.'][' '][dd][d]" +
-                    "[[' ']['T']HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X]]]");
-    private static final DateTimeFormatter timeFormatter =
-            DateTimeFormatter.ofPattern("HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS]]");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("[yyyy][yy]['-']['/']['.'][' '][MMM][MM][M]['-']['/']['.'][' '][dd][d]"
+                + "[[' ']['T']HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X][' '][G]]]");
+    private static final DateTimeFormatter DATE_FORMATTER =
+        DateTimeFormatter.ofPattern("[yyyy][yy]['-']['/']['.'][' '][MMM][MM][M]['-']['/']['.'][' '][dd][d][[' '][G]]");
+    private static final DateTimeFormatter TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X]]");
 
     /**
      * Parse the Json date-time logical type to an Avro long value.
      * @return the number of microseconds from the unix epoch, 1 January 1970 00:00:00.000000 UTC.
      */
     public static Long getEpochMicros(String jsonDateTime) {
+        jsonDateTime = cleanLineBreaks(jsonDateTime);
         Instant instant = null;
         if (jsonDateTime.matches("-?\\d+")) {
             return Long.valueOf(jsonDateTime);
         }
         try {
-            ZonedDateTime zdt = ZonedDateTime.parse(jsonDateTime, formatter);
+            ZonedDateTime zdt = ZonedDateTime.parse(jsonDateTime, DATE_TIME_FORMATTER);
             instant = zdt.toInstant();
         } catch (DateTimeParseException e) {
             try {
-                LocalDateTime dt = LocalDateTime.parse(jsonDateTime, formatter);
+                LocalDateTime dt = LocalDateTime.parse(jsonDateTime, DATE_TIME_FORMATTER);
                 instant = dt.toInstant(ZoneOffset.UTC);
             } catch (DateTimeParseException ex) {
                 // no logging since it may generate too much noise
@@ -45,9 +48,10 @@ public class DateTimeUtils {
      * @return the number of days from the unix epoch, 1 January 1970 (ISO calendar).
      */
     public static Integer getEpochDay(String jsonDate) {
+        jsonDate = cleanLineBreaks(jsonDate);
         Integer epochDay = null;
         try {
-            LocalDate date = LocalDate.parse(jsonDate, formatter);
+            LocalDate date = LocalDate.parse(jsonDate, DATE_FORMATTER);
             epochDay = (int) date.toEpochDay();
         } catch (DateTimeParseException e) {
             // no logging since it may generate too much noise
@@ -60,21 +64,26 @@ public class DateTimeUtils {
      * @return the number of microseconds after midnight, 00:00:00.000000.
      */
     public static Long getMicroSeconds(String jsonTime) {
+        jsonTime = cleanLineBreaks(jsonTime);
         Long nanoOfDay = null;
         if (jsonTime.matches("-?\\d+")) {
             return Long.valueOf(jsonTime);
         }
         try {
-            LocalTime time = LocalTime.parse(jsonTime, timeFormatter);
+            LocalTime time = LocalTime.parse(jsonTime, TIME_FORMATTER);
             nanoOfDay = time.toNanoOfDay();
         } catch (DateTimeParseException e) {
             try {
-                LocalTime time = LocalTime.parse(jsonTime, formatter);
+                LocalTime time = LocalTime.parse(jsonTime, DATE_TIME_FORMATTER);
                 nanoOfDay = time.toNanoOfDay();
             } catch (DateTimeParseException ex) {
                 // no logging since it may generate too much noise
             }
         }
         return nanoOfDay == null ? null : nanoOfDay / 1000;
+    }
+
+    private static String cleanLineBreaks(String jsonDateTime) {
+        return jsonDateTime.replace("\n", "").replace("\r", "");
     }
 }

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -96,7 +96,7 @@ class JsonAvroConverterSpec extends Specification {
         toMap(json) == toMap(converter.convertToJson(avro, schema))
     }
 
-    def "should throw exception when parsing record with mismatched primitives"() {
+    def "should throw exception when parsing not valid string number"() {
         given:
         def schema = '''
             {
@@ -122,7 +122,7 @@ class JsonAvroConverterSpec extends Specification {
 
         then:
         def e = thrown AvroConversionException
-        e.message == "Failed to convert JSON to Avro: Field field_integer is expected to be type: java.lang.Number, but it is: foobar"
+        e.message == "Failed to convert JSON to Avro: Field field_integer is expected to be Number format, but it is: foobar"
     }
 
     def "should ignore unknown fields"() {

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/DateTimeUtilsTest.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/DateTimeUtilsTest.java
@@ -37,16 +37,23 @@ public class DateTimeUtilsTest {
         assertEquals(1609462861000000L, getEpochMicros("2021-01-01T01:01:01+0000"));
         assertEquals(1609462861000000L, getEpochMicros("2021-01-01T01:01:01UTC"));
         assertEquals(1609459261000000L, getEpochMicros("2021-01-01T01:01:01+01"));
+        assertEquals(-125941863974322000L, getEpochMicros("2022-01-23T01:23:45.678-11:30 BC"));
+        assertEquals(1642942425678000L, getEpochMicros("2022-01-23T01:23:45.678-11:30"));
 
         assertEquals(18628, getEpochDay("2021-1-1"));
         assertEquals(18628, getEpochDay("2021-01-01"));
         assertEquals(18629, getEpochDay("2021/01/02"));
         assertEquals(18630, getEpochDay("2021.01.03"));
         assertEquals(18631, getEpochDay("2021 Jan 04"));
+        assertEquals(-1457318, getEpochDay("2021-1-1 BC"));
 
         assertEquals(3661000000L, getMicroSeconds("01:01:01"));
         assertEquals(3660000000L, getMicroSeconds("01:01"));
         assertEquals(44581541000L, getMicroSeconds("12:23:01.541"));
         assertEquals(44581541214L, getMicroSeconds("12:23:01.541214"));
+
+        // clean line breaks
+        assertEquals(1585612800000000L, getEpochMicros("2020-03-\n31T00:00:00Z\r"));
+        assertEquals(18628, getEpochDay("2021-\n1-1\r"));
     }
 }

--- a/converter/src/test/resources/json_avro_converter.json
+++ b/converter/src/test/resources/json_avro_converter.json
@@ -74,6 +74,56 @@
     }
   },
   {
+    "testCase": "numbers_schema",
+    "avroSchema": {
+      "type": "record",
+      "name": "test_schema",
+      "fields": [
+        {
+          "name": "int_string_field",
+          "type": "int"
+        },
+        {
+          "name": "int_field",
+          "type": "int"
+        },
+        {
+          "name": "long_string_field",
+          "type": "long"
+        },
+        {
+          "name": "long_field",
+          "type": "long"
+        },
+        {
+          "name": "double_string_field",
+          "type": "double"
+        },
+        {
+          "name": "double_field",
+          "type": "double"
+        }
+      ]
+    },
+    "jsonObject": {
+      "int_string_field": "100",
+      "int_field": 100,
+      "long_string_field": "1000000000",
+      "long_field": 1000000000,
+      "double_string_field": "100.2",
+      "double_field": 100.2
+
+    },
+    "avroObject": {
+      "int_string_field" : 100,
+      "int_field": 100,
+      "long_string_field": 1000000000,
+      "long_field": 1000000000,
+      "double_string_field": 100.2,
+      "double_field": 100.2
+    }
+  },
+  {
     "testCase": "not_expecting_extra_fields",
     "avroSchema": {
       "type": "record",
@@ -716,6 +766,32 @@
     },
     "avroObject": {
       "array_field": [101, "102", true, false, null]
+    }
+  },
+  {
+    "testCase": "typed_array_string_number_plus_text",
+    "avroSchema": {
+      "type": "record",
+      "name": "typed_array",
+      "fields": [
+        {
+          "name": "array_field",
+          "type": [
+            "null",
+            {
+              "type": "array",
+              "items": ["null", "int", "string", "boolean"]
+            }
+          ],
+          "default": null
+        }
+      ]
+    },
+    "jsonObject": {
+      "array_field": ["101", "102", "text", true, false, null]
+    },
+    "avroObject": {
+      "array_field": [101, 102, "text", true, false, null]
     }
   },
   {


### PR DESCRIPTION
## Summary
- Time with timezone: `01:23:45.678-11:30`
- Added Era date time support: ` 2022-01-23T01:23:45.678-11:30 BC`
- Added support:  `Infinity, -Infinity, NaN`

## Recommended Order
1. JsonGenericRecordReader.java
2. DateTimeUtils.java
3. AvroTypeExceptions.java
4. json_avro_converter.json

## Checklist
- [✅] Added unit tests
- [✅] Make sure there is no logging in the Json / Avro conversion code
- [✅] Update documentation in `README.md`
