### PR TITLE
Epic 8349 certify s3/issue 8556 s3 v2 fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,22 @@ JsonAvroConverter converter = JsonAvroConverter.builder()
 
 By default, both `_ab_additional_properties` and `_airbyte_additional_properties` are the additional properties field names on the Json object.
 
+### Field Conversion Failure Listener
+
+A listener can be set to react to conversion failures at the field level. It will be called with metadata about the field and failure, and it may do one of the following:
+
+* return a replacement value for the field
+* register a post-processing method for the record to add metadata about the failure to the record's metadata
+* (re)throw an exception if the failure is unrecoverable
+
+Note that it may not edit the record itself. This is to avoid race conditions and other issues that might arise from modifying the record while it is being processed.
+
+```java
+JsonAvroConverter converter = JsonAvroConverter.builder()
+    .setFieldConversionFailureListener(listener)
+    .build();
+```
+
 ## Build
 - The build is upgraded to use Java 14 and Gradle 7.2 to match the build environment of Airbyte.
 - Maven staging and publishing is removed because they are incompatible with the new build environment.

--- a/converter/build.gradle
+++ b/converter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.14.0'
+        classpath 'com.github.davidmc24.gradle.plugin:gradle-avro-plugin:1.0.0'
     }
 }
 
@@ -20,7 +20,7 @@ plugins {
     id 'pmd'
 }
 
-apply plugin: 'com.commercehub.gradle.plugin.avro'
+apply plugin: 'com.github.davidmc24.gradle.plugin.avro'
 apply plugin: 'idea'
 
 configurations {

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListener.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListener.java
@@ -1,0 +1,55 @@
+package tech.allegro.schema.json2avro.converter;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+public abstract class FieldConversionFailureListener {
+    /**
+     * This is to support behavior like v2 destinations change capture.
+     *
+     * Specifically, when a field fails to convert:
+     *   * the field, change, and reason are added to `_airbyte_metadata.changes[]`
+     *   * the field is nulled or truncated
+     *
+     * At the time of failure, the _airbyte_metadata.changes[] field might
+     *   * exist and be empty
+     *   * exist and already contain changes
+     *   * not have been parsed yet (meta == null)
+     *   * have been parsed, but contain a changes field that has not been parsed (meta.changes == null)
+     *
+     * Therefore, the simplest general feature that will support the desired behavior is
+     *   * listener may return a new value for the affected field only
+     *   * listener may not mutate any other part of the record on failure
+     *   * listener may only push post-processing actions for the record (after required fields definitely exist)
+     *
+     */
+
+    private final List<Function<GenericData.Record, GenericData.Record>> postProcessingActions = new LinkedList<>();
+
+    protected final void pushPostProcessingAction(Function<GenericData.Record, GenericData.Record> action) {
+        postProcessingActions.add(action);
+    }
+
+    public abstract Object onFieldConversionFailure(String avroName,
+                                                    String originalName,
+                                                    Schema schema,
+                                                    Object value,
+                                                    String path,
+                                                    Exception exception);
+
+    public final GenericData.Record flushPostProcessingActions(GenericData.Record record) {
+        for (Function<GenericData.Record, GenericData.Record> action : postProcessingActions) {
+            record = action.apply(record);
+        }
+        postProcessingActions.clear();
+        return record;
+    }
+
+    public final void reset() {
+        postProcessingActions.clear();
+    }
+}

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListener.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListener.java
@@ -3,6 +3,8 @@ package tech.allegro.schema.json2avro.converter;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
@@ -34,14 +36,16 @@ public abstract class FieldConversionFailureListener {
         postProcessingActions.add(action);
     }
 
-    public abstract Object onFieldConversionFailure(String avroName,
-                                                    String originalName,
-                                                    Schema schema,
-                                                    Object value,
-                                                    String path,
-                                                    Exception exception);
+    @Nullable
+    public abstract Object onFieldConversionFailure(@Nonnull String avroName,
+                                                    @Nonnull String originalName,
+                                                    @Nonnull Schema schema,
+                                                    @Nonnull Object value,
+                                                    @Nonnull String path,
+                                                    @Nonnull Exception exception);
 
-    public final GenericData.Record flushPostProcessingActions(GenericData.Record record) {
+    @Nonnull
+    public final GenericData.Record flushPostProcessingActions(@Nonnull GenericData.Record record) {
         for (Function<GenericData.Record, GenericData.Record> action : postProcessingActions) {
             record = action.apply(record);
         }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
@@ -57,6 +57,11 @@ public class JsonAvroConverter {
             return this;
         }
 
+        public Builder setFieldConversionFailureListener(FieldConversionFailureListener listener) {
+            recordReaderBuilder.setFieldConversionFailureListener(listener);
+            return this;
+        }
+
         public JsonAvroConverter build() {
             return new JsonAvroConverter(recordReaderBuilder.build());
         }

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListenerTest.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListenerTest.java
@@ -40,6 +40,7 @@ public class FieldConversionFailureListenerTest {
         final Schema metaSchema = avroSchema.getField("META").schema();
         final Schema changesSchema = metaSchema.getField("CHANGES").schema().getElementType().getTypes().get(0);
         final List<String> expectedRecords = toList(expectedOutputJson.elements()).stream().map(JsonNode::toString).toList();
+
         final JsonAvroConverter converter = JsonAvroConverter.builder()
                 .setNameTransformer(String::toUpperCase)
                 .setFieldConversionFailureListener(new FieldConversionFailureListener() {

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListenerTest.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/FieldConversionFailureListenerTest.java
@@ -1,0 +1,85 @@
+package tech.allegro.schema.json2avro.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static tech.allegro.schema.json2avro.converter.TestUtils.readResource;
+import static tech.allegro.schema.json2avro.converter.TestUtils.toList;
+
+public class FieldConversionFailureListenerTest {
+    public static class FieldConversionFailureListenerTestProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) throws Exception {
+            final JsonNode desc = JsonHelper.deserialize(readResource("field_conversion_failure_listener.json"));
+            return toList(desc.get("testCases").elements()).stream().map(testCase -> Arguments.of(
+                    testCase.get("name").asText(),
+                    desc.get("avroSchema"),
+                    testCase.get("records"),
+                    testCase.get("expectedOutput")));
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FieldConversionFailureListenerTestProvider.class)
+    public void testFieldConversionFailureListener(String testCaseName,
+                                                   JsonNode avroSchemaJson,
+                                                   JsonNode recordsJson,
+                                                   JsonNode expectedOutputJson){
+        final Schema avroSchema = new Schema.Parser().parse(JsonHelper.serialize(avroSchemaJson));
+        final Schema metaSchema = avroSchema.getField("META").schema();
+        final Schema changesSchema = metaSchema.getField("CHANGES").schema().getElementType().getTypes().get(0);
+        final List<String> expectedRecords = toList(expectedOutputJson.elements()).stream().map(JsonNode::toString).toList();
+        final JsonAvroConverter converter = JsonAvroConverter.builder()
+                .setNameTransformer(String::toUpperCase)
+                .setFieldConversionFailureListener(new FieldConversionFailureListener() {
+                    @Override
+                    public Object onFieldConversionFailure(String avroName,
+                                                           String originalName,
+                                                           Schema schema,
+                                                           Object value,
+                                                           String path,
+                                                           Exception exception) {
+                        pushPostProcessingAction(record -> {
+                            GenericData.Record change = new GenericRecordBuilder(changesSchema)
+                                    .set("FIELD", originalName)
+                                    .set("CHANGE", "NULLED")
+                                    .set("REASON", exception.getMessage())
+                                    .build();
+                            GenericData.Record meta = (GenericData.Record) record.get("META");
+                            Object changesObj = meta.get("CHANGES");
+                            @SuppressWarnings("unchecked")
+                            List<GenericData.Record> changes = (List<GenericData.Record>) changesObj;
+                            changes.add(change);
+
+                            return record;
+                        });
+                        return null;
+                    }
+                })
+                .build();
+
+        // Run twice to guard against state leaking across runs
+        for (int run: List.of(1, 2)) {
+            int i = 0;
+            for (JsonNode recordJson : recordsJson) {
+                final GenericData.Record record = converter.convertToGenericDataRecord(
+                        JsonHelper.serialize(recordJson).getBytes(),
+                        avroSchema);
+                String recordReformatted = JsonHelper.serialize(JsonHelper.deserialize(record.toString()));
+                assertEquals(expectedRecords.get(i), recordReformatted, String.format("Test run %d for %s failed", run, testCaseName));
+                i++;
+            }
+        }
+    }
+}

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/JsonAvroConverterTest.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/JsonAvroConverterTest.java
@@ -100,6 +100,7 @@ public class JsonAvroConverterTest {
         .setJsonAdditionalPropsFieldNames(jsonExtraPropsFieldNames)
         .setAvroAdditionalPropsFieldName(avroExtraPropsFieldName)
         .build();
+
     final Schema schema =  new Schema.Parser().parse(JsonHelper.serialize(avroSchema));
     final GenericData.Record actualAvroObject = converter.convertToGenericDataRecord(WRITER.writeValueAsBytes(jsonObject), schema);
     assertEquals(avroObject, JsonHelper.deserialize(actualAvroObject.toString()), String.format("Test for %s failed", testCaseName));

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/JsonAvroConverterTest.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/JsonAvroConverterTest.java
@@ -1,6 +1,8 @@
 package tech.allegro.schema.json2avro.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static tech.allegro.schema.json2avro.converter.TestUtils.readResource;
+import static tech.allegro.schema.json2avro.converter.TestUtils.toList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -18,8 +20,12 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,20 +36,6 @@ public class JsonAvroConverterTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final ObjectWriter WRITER = MAPPER.writer();
-
-  @SuppressWarnings("UnstableApiUsage")
-  public static String readResource(final String name) throws IOException {
-    final URL resource = Resources.getResource(name);
-    return Resources.toString(resource, StandardCharsets.UTF_8);
-  }
-
-  private static <T> List<T> toList(final Iterator<T> iterator) {
-    final List<T> list = new ArrayList<>();
-    while (iterator.hasNext()) {
-      list.add(iterator.next());
-    }
-    return list;
-  }
 
   private static <T> Set<T> toSet(final Iterator<T> iterator) {
     final Set<T> set = new HashSet<>();
@@ -112,5 +104,4 @@ public class JsonAvroConverterTest {
     final GenericData.Record actualAvroObject = converter.convertToGenericDataRecord(WRITER.writeValueAsBytes(jsonObject), schema);
     assertEquals(avroObject, JsonHelper.deserialize(actualAvroObject.toString()), String.format("Test for %s failed", testCaseName));
   }
-
 }

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/TestUtils.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/TestUtils.java
@@ -1,0 +1,26 @@
+package tech.allegro.schema.json2avro.converter;
+
+import com.google.common.io.Resources;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class TestUtils {
+    @SuppressWarnings("UnstableApiUsage")
+    public static String readResource(final String name) throws IOException {
+        final URL resource = Resources.getResource(name);
+        return Resources.toString(resource, StandardCharsets.UTF_8);
+    }
+
+    public static <T> List<T> toList(final Iterator<T> iterator) {
+        final List<T> list = new ArrayList<>();
+        while (iterator.hasNext()) {
+            list.add(iterator.next());
+        }
+        return list;
+    }
+}

--- a/converter/src/test/resources/field_conversion_failure_listener.json
+++ b/converter/src/test/resources/field_conversion_failure_listener.json
@@ -1,0 +1,238 @@
+{
+  "avroSchema": {
+    "type": "record",
+    "name": "message",
+    "fields": [
+      {
+        "name": "META",
+        "type": {
+          "type": "record",
+          "name": "meta",
+          "fields": [
+            {
+              "name": "CHANGES",
+              "type": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "record",
+                    "name": "change",
+                    "fields": [
+                      {
+                        "name": "FIELD",
+                        "type": "string"
+                      },
+                      {
+                        "name": "CHANGE",
+                        "type": "string"
+                      },
+                      {
+                        "name": "REASON",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "DATA",
+        "type": {
+          "type": "record",
+          "name": "data",
+          "fields": [
+            {
+              "name": "NAME",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "ID",
+              "type": [
+                "null",
+                "int"
+              ],
+              "default": null
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "testCases": [
+    {
+      "name": "no bad records, some existing changes",
+      "records": [
+        {
+          "meta": {
+            "changes": [
+              {
+                "field": "name",
+                "change": "TRUNCATED",
+                "reason": "name was ridiculously long"
+              }
+            ]
+          },
+          "data": {
+            "name": "Bob",
+            "id": 1
+          }
+        },
+        {
+          "meta": {
+            "changes": []
+          },
+          "data": {
+            "name": "Alice",
+            "id": 2
+          }
+        }
+      ],
+      "expectedOutput": [
+        {
+          "META": {
+            "CHANGES": [
+              {
+                "FIELD": "name",
+                "CHANGE": "TRUNCATED",
+                "REASON": "name was ridiculously long"
+              }
+            ]
+          },
+          "DATA": {
+            "NAME": "Bob",
+            "ID": 1
+          }
+        },
+        {
+          "META": {
+            "CHANGES": []
+          },
+          "DATA": {
+            "NAME": "Alice",
+            "ID": 2
+          }
+        }
+      ]
+    },
+    {
+      "name": "bad record with empty changes",
+      "records": [
+        {
+          "meta": {
+            "changes": []
+          },
+          "data": {
+            "name": [
+              "B",
+              "o",
+              "b"
+            ],
+            "id": 1
+          }
+        },
+        {
+          "meta": {
+            "changes": []
+          },
+          "data": {
+            "name": "Alice",
+            "id": 2
+          }
+        }
+      ],
+      "expectedOutput": [
+          {
+              "META": {
+                  "CHANGES": [
+                      {
+                          "FIELD": "name",
+                          "CHANGE": "NULLED",
+                          "REASON": "Could not evaluate union, field NAME is expected to be one of these: NULL, STRING. If this is a complex type, check if offending field (path: DATA.NAME) adheres to schema: [B, o, b]"
+                      }
+                  ]
+              },
+              "DATA": {
+                  "NAME": null,
+                  "ID": 1
+              }
+          },
+          {
+              "META": {
+                  "CHANGES": []
+              },
+              "DATA": {
+                  "NAME": "Alice",
+                  "ID": 2
+              }
+          }
+        ]
+    },
+    {
+      "name": "bad record with existing changes",
+        "records": [
+          {
+            "meta": {
+              "changes": [
+                {
+                  "field": "id",
+                  "change": "CONVERTED",
+                  "reason": "was string"
+                }
+              ]
+            },
+            "data": {
+              "name": 808,
+              "id": 2
+            }
+          },
+          {
+            "meta": {
+              "changes": []
+            },
+            "data": {
+              "name": "Alice",
+              "id": 2
+            }
+          }
+        ],
+        "expectedOutput": [
+            {
+                "META": {
+                    "CHANGES": [
+                        {
+                            "FIELD": "id",
+                            "CHANGE": "CONVERTED",
+                            "REASON": "was string"
+                        },
+                        {
+                            "FIELD": "name",
+                            "CHANGE": "NULLED",
+                            "REASON": "Could not evaluate union, field NAME is expected to be one of these: NULL, STRING. If this is a complex type, check if offending field (path: DATA.NAME) adheres to schema: 808"
+                        }
+                    ]
+                },
+                "DATA": {
+                    "NAME": null,
+                    "ID": 2
+                }
+            },
+            {
+                "META": {
+                    "CHANGES": []
+                },
+                "DATA": {
+                    "NAME": "Alice",
+                    "ID": 2
+                }
+            }
+        ]
+    }
+  ]
+}


### PR DESCRIPTION
**⚠️ Please create this PR against `airbytehq/json-avro-converter` as the base repository, instead of the default `allegro/json-avro-converter`.⚠️**

## Summary

This is to provide support for capturing field-level conversion failures when converting from json to avro. It adds a `FieldConversionFailureListener` option to the record reader, which provides a hook for replacing the field value and adding metadata to the record when a failure occurs.

Most of the changes here are to support that. Additionally I had to thread the original field name through the reader so that it could be added to the metadata if needed. (Sometimes the field name is edited to make it avro compatible.)

## Checklist
- [x] Write unit tests
- [x] Make sure there is no logging in the Json / Avro conversion code
- [x] Update documentation in `README.md`

## Reviewers
* @stephane-airbyte : visibility/gotcha-check
* @gisripa: full review