### PR TITLE
Avro time converter respects timezone

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/util/DateTimeUtils.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/util/DateTimeUtils.java
@@ -1,11 +1,6 @@
 package tech.allegro.schema.json2avro.converter.util;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
@@ -67,14 +62,28 @@ public class DateTimeUtils {
             return Long.valueOf(jsonTime);
         }
         try {
-            LocalTime time = LocalTime.parse(jsonTime, TIME_FORMATTER);
-            nanoOfDay = time.toNanoOfDay();
-        } catch (DateTimeParseException e) {
+            // This will only succeed if the time has a timezone.
+            OffsetTime time = OffsetTime.parse(jsonTime, TIME_FORMATTER);
+            nanoOfDay = time.toLocalTime().toNanoOfDay();
+
+            // Apply the offset, wrapping around midnight.
+            nanoOfDay -= time.getOffset().getTotalSeconds() * 1_000_000_000L;
+            if (nanoOfDay < 0) {
+                nanoOfDay += 24 * 60 * 60 * 1_000_000_000L;
+            }
+        } catch (DateTimeException e) {
             try {
-                LocalTime time = LocalTime.parse(jsonTime, DATE_TIME_FORMATTER);
+                // Works on any correctly formatted time without a timezone
+                LocalTime time = LocalTime.parse(jsonTime, TIME_FORMATTER);
                 nanoOfDay = time.toNanoOfDay();
             } catch (DateTimeParseException ex) {
-                // no logging since it may generate too much noise
+                try {
+                    // Catchall
+                    LocalTime time = LocalTime.parse(jsonTime, DATE_TIME_FORMATTER);
+                    nanoOfDay = time.toNanoOfDay();
+                } catch (DateTimeParseException exc) {
+                    // no logging since it may generate too much noise
+                }
             }
         }
         return nanoOfDay == null ? null : nanoOfDay / 1000;

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/util/DateTimeUtils.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/util/DateTimeUtils.java
@@ -66,7 +66,10 @@ public class DateTimeUtils {
             OffsetTime time = OffsetTime.parse(jsonTime, TIME_FORMATTER);
             nanoOfDay = time.toLocalTime().toNanoOfDay();
 
-            // Apply the offset, wrapping around midnight.
+            // Apply the offset. The results of this operation might be negative.
+            // For example, if the time is 02:00:00+03:00, the time at UTC
+            // is 23:00 the previous day (ie, -01:00). Negative results are added
+            // to 24 hours to get the correct result. (-01:00 + 24:00 = 23:00.)
             nanoOfDay -= time.getOffset().getTotalSeconds() * 1_000_000_000L;
             if (nanoOfDay < 0) {
                 nanoOfDay += 24 * 60 * 60 * 1_000_000_000L;

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/DateTimeUtilsTest.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/DateTimeUtilsTest.java
@@ -52,6 +52,7 @@ public class DateTimeUtilsTest {
         assertEquals(44581541000L, getMicroSeconds("12:23:01.541"));
         assertEquals(44581541214L, getMicroSeconds("12:23:01.541214"));
         assertEquals(39600000000L, getMicroSeconds("12:00:00.000000+01:00"));
+        assertEquals(39600000000L, getMicroSeconds("10:00:00.000000-01:00"));
         assertEquals(84600000000L, getMicroSeconds("03:30:00.000000+04:00"));
     }
 

--- a/converter/src/test/java/tech/allegro/schema/json2avro/converter/DateTimeUtilsTest.java
+++ b/converter/src/test/java/tech/allegro/schema/json2avro/converter/DateTimeUtilsTest.java
@@ -51,6 +51,8 @@ public class DateTimeUtilsTest {
         assertEquals(3660000000L, getMicroSeconds("01:01"));
         assertEquals(44581541000L, getMicroSeconds("12:23:01.541"));
         assertEquals(44581541214L, getMicroSeconds("12:23:01.541214"));
+        assertEquals(39600000000L, getMicroSeconds("12:00:00.000000+01:00"));
+        assertEquals(84600000000L, getMicroSeconds("03:30:00.000000+04:00"));
     }
 
     @Test

--- a/converter/src/test/resources/field_conversion_failure_listener.json
+++ b/converter/src/test/resources/field_conversion_failure_listener.json
@@ -59,6 +59,17 @@
                 "int"
               ],
               "default": null
+            },
+            {
+              "name": "TIME_WITH_TIMEZONE",
+              "type": [
+                "null",
+                {
+                  "type": "long",
+                  "logicalType": "time-micros"
+                }
+              ],
+              "default": null
             }
           ]
         }
@@ -81,7 +92,8 @@
           },
           "data": {
             "name": "Bob",
-            "id": 1
+            "id": 1,
+            "time_with_timezone": "04:00:00+05:30"
           }
         },
         {
@@ -90,7 +102,8 @@
           },
           "data": {
             "name": "Alice",
-            "id": 2
+            "id": 2,
+            "time_with_timezone": "12:00:00"
           }
         }
       ],
@@ -107,7 +120,8 @@
           },
           "DATA": {
             "NAME": "Bob",
-            "ID": 1
+            "ID": 1,
+            "TIME_WITH_TIMEZONE": 81000000000
           }
         },
         {
@@ -116,7 +130,8 @@
           },
           "DATA": {
             "NAME": "Alice",
-            "ID": 2
+            "ID": 2,
+            "TIME_WITH_TIMEZONE": 43200000000
           }
         }
       ]
@@ -134,7 +149,8 @@
               "o",
               "b"
             ],
-            "id": 1
+            "id": 1,
+            "time_with_timezone": "04:00:00.000+05:30"
           }
         },
         {
@@ -143,7 +159,8 @@
           },
           "data": {
             "name": "Alice",
-            "id": 2
+            "id": 2,
+            "time_with_timezone": "12:00:00.000"
           }
         }
       ],
@@ -160,7 +177,8 @@
               },
               "DATA": {
                   "NAME": null,
-                  "ID": 1
+                  "ID": 1,
+                  "TIME_WITH_TIMEZONE": 81000000000
               }
           },
           {
@@ -169,7 +187,8 @@
               },
               "DATA": {
                   "NAME": "Alice",
-                  "ID": 2
+                  "ID": 2,
+                  "TIME_WITH_TIMEZONE": 43200000000
               }
           }
         ]
@@ -189,7 +208,8 @@
             },
             "data": {
               "name": 808,
-              "id": 2
+              "id": 2,
+              "time_with_timezone": "04:00:00+05:30"
             }
           },
           {
@@ -198,7 +218,8 @@
             },
             "data": {
               "name": "Alice",
-              "id": 2
+              "id": 2,
+              "time_with_timezone": "12:00:00Z"
             }
           }
         ],
@@ -220,7 +241,8 @@
                 },
                 "DATA": {
                     "NAME": null,
-                    "ID": 2
+                    "ID": 2,
+                    "TIME_WITH_TIMEZONE": 81000000000
                 }
             },
             {
@@ -229,10 +251,64 @@
                 },
                 "DATA": {
                     "NAME": "Alice",
-                    "ID": 2
+                    "ID": 2,
+                    "TIME_WITH_TIMEZONE": 43200000000
                 }
             }
         ]
+    },
+    {
+      "name": "record with malformed timezone",
+      "records": [
+        {
+          "meta": {
+            "changes": []
+          },
+          "data": {
+            "name": "Bob",
+            "id": 1,
+            "time_with_timezone": "04:00:00+05:30"
+          }
+        },
+        {
+          "meta": {
+            "changes": []
+          },
+          "data": {
+            "name": "Alice",
+            "id": 2,
+            "time_with_timezone": "12:00:00-3:00"
+          }
+        }
+      ],
+      "expectedOutput": [
+        {
+          "META": {
+            "CHANGES": []
+          },
+          "DATA": {
+            "NAME": "Bob",
+            "ID": 1,
+            "TIME_WITH_TIMEZONE": 81000000000
+          }
+        },
+        {
+          "META": {
+            "CHANGES": [
+              {
+                "FIELD": "time_with_timezone",
+                "CHANGE": "NULLED",
+                "REASON": "Could not evaluate union, field TIME_WITH_TIMEZONE is expected to be one of these: NULL, LONG. If this is a complex type, check if offending field (path: DATA.TIME_WITH_TIMEZONE) adheres to schema: 12:00:00-3:00"
+              }
+            ]
+          },
+          "DATA": {
+            "NAME": "Alice",
+            "ID": 2,
+            "TIME_WITH_TIMEZONE": null
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Addresses [this bug](https://github.com/airbytehq/airbyte-internal-issues/issues/9170) (internally reported by me during S3 testing)

When a time with a timezone is converted to time of day, the timezone is ignored:

Given some input data like
```
"time_wo_tz":"03:20:48",
"time_w_tz":"07:53:25.917663+05:00
```

The output is
```
time_wo_tz:
12048000000 => / 1000000 / 3600 => 3.34... => 3:20:48...
time_w_tz:
28405917663 => / 1000000 / 3600 => 7.89.. => 7:53:43...
```

When we should expect
```
time_wo_tz:
12048000000 => / 1000000 / 3600 => 3.34... => 3:20:48...
time_w_tz:
10405917663 => / 1000000 / 3600 => 2.89.. => 2:53:43...
```

**NOTE: I'm doing this here and not in the PR that implements new style field conversions, because there is currently no way to pass `logicalType="time-micros"` through after converting a timestamp to a long in json-schema. I decided to hold off until refactoring it for the CDK (which will entail changing the schema mapper from using json-schema to using a bespoke airbyte type + migrating avro schema and record processing to the schema/record mappers).

## Checklist
- [X ] Write unit tests
- [X] Make sure there is no logging in the Json / Avro conversion code
- [n/a] Update documentation in `README.md`
